### PR TITLE
Add pagination to PR retrieval

### DIFF
--- a/src/Github/Api/listPullRequestsService.ts
+++ b/src/Github/Api/listPullRequestsService.ts
@@ -1,4 +1,5 @@
 import {GitHub} from '@actions/github';
+import {Octokit} from '@octokit/rest';
 
 export interface ListPullRequestsService {
     listOpenPullRequests(ownerName: string, repoName: string): Promise<ApiListPullRequest[]>;
@@ -13,17 +14,25 @@ export class GithubListPullRequestsService implements ListPullRequestsService {
     constructor(private github: GitHub) {}
 
     async listOpenPullRequests(ownerName: string, repoName: string): Promise<ApiListPullRequest[]> {
-        const {data: data} = await this.github.pulls.list({
+        const options = this.github.pulls.list.endpoint.merge({
             owner: ownerName,
             repo: repoName,
             state: 'open',
         });
 
-        return data.map((value) => {
-            return {
-                number: value.number,
-                labels: value.labels.map((label) => label.name),
-            };
-        });
+        const openPulls: ApiListPullRequest[] = [];
+        for await (const response of this.github.paginate.iterator(options)) {
+            const data = response.data as Octokit.PullsListResponse;
+            openPulls.push(
+                ...data.map((value) => {
+                    return {
+                        number: value.number,
+                        labels: value.labels.map((label) => label.name),
+                    };
+                }),
+            );
+        }
+
+        return openPulls;
     }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import {getInput, setFailed} from '@actions/core';
 import {context, GitHub} from '@actions/github';
-import Webhooks from '@octokit/webhooks';
+import {EventPayloads} from '@octokit/webhooks';
 import {EligiblePullRequestsRetriever} from './EligiblePullRequests/eligiblePullRequestsRetriever';
 import {Rebaser} from './rebaser';
 import {TestableEligiblePullRequestsRetriever} from './EligiblePullRequests/testableEligiblePullRequestsRetriever';
@@ -24,7 +24,7 @@ async function run(): Promise<void> {
         const rebaser = new Rebaser(github);
         const labeler = new Labeler(openPullRequestsProvider, new GithubLabelPullRequestService(github));
 
-        const payload = context.payload as Webhooks.WebhookPayloadPush;
+        const payload = context.payload as EventPayloads.WebhookPayloadPush;
 
         const ownerName = payload.repository.owner.login;
         const repoName = payload.repository.name;


### PR DESCRIPTION
Previously, only 30 PRs would be returned from `listOpenPullRequests`. Here, we paginate over the pull requests.