### PR TITLE
Don't ignore blocked pull requests

### DIFF
--- a/src/EligiblePullRequests/__tests__/testableEligiblePullRequestsRetriever.test.ts
+++ b/src/EligiblePullRequests/__tests__/testableEligiblePullRequestsRetriever.test.ts
@@ -56,6 +56,37 @@ describe('A pull request is eligible', () => {
             },
         ]);
     });
+
+    it(`when it is rebaseable, the mergeableState is 'blocked' and it has the label '${OPT_IN_LABEL}'`, async () => {
+        /* Given */
+        testOpenPullRequestsProvider.openPullRequestsValue = [
+            {
+                ownerName: 'owner',
+                repoName: 'repo',
+                number: 3,
+                draft: false,
+                rebaseable: true,
+                mergeableState: 'blocked',
+                labels: [OPT_IN_LABEL],
+            },
+        ];
+
+        /* When */
+        const results = await retriever.findEligiblePullRequests('owner', 'repo');
+
+        /* Then */
+        expect(results).toStrictEqual([
+            {
+                ownerName: 'owner',
+                repoName: 'repo',
+                number: 3,
+                draft: false,
+                rebaseable: true,
+                mergeableState: 'blocked',
+                labels: [OPT_IN_LABEL],
+            },
+        ]);
+    });
 });
 
 describe('A pull request is not eligible', () => {
@@ -80,7 +111,7 @@ describe('A pull request is not eligible', () => {
         expect(results).toStrictEqual([]);
     });
 
-    each([['blocked'], ['clean'], ['dirty'], ['unknown'], ['unstable']]).it(
+    each([['clean'], ['dirty'], ['unknown'], ['unstable']]).it(
         "when the mergeableState is '%s'",
         async (mergeableState: MergeableState) => {
             /* Given */

--- a/src/EligiblePullRequests/testableEligiblePullRequestsRetriever.ts
+++ b/src/EligiblePullRequests/testableEligiblePullRequestsRetriever.ts
@@ -40,8 +40,10 @@ export class TestableEligiblePullRequestsRetriever implements EligiblePullReques
             return false;
         }
 
-        if (pullRequestInfo.mergeableState !== 'behind') {
-            info(`PR #${pullRequestInfo.number} is not 'behind', but: '${pullRequestInfo.mergeableState}'.`);
+        if (pullRequestInfo.mergeableState !== 'behind' && pullRequestInfo.mergeableState !== 'blocked') {
+            info(
+                `PR #${pullRequestInfo.number} is not 'behind' or 'blocked', but: '${pullRequestInfo.mergeableState}'.`,
+            );
             return false;
         }
 


### PR DESCRIPTION
Based on https://github.com/octokit/octokit.net/issues/1763 the
'blocked' state represents "Blocked by a failing/missing required
status check". Since there are no conflicts at this point, a rebase
is possible and might even be able to fix the status checks.

Replaces #44, fixes #39