### PR TITLE
Fix false 'not rebaseable' when GitHub API returns null

### DIFF
--- a/src/Github/Api/getPullRequestService.ts
+++ b/src/Github/Api/getPullRequestService.ts
@@ -7,7 +7,7 @@ export interface GetPullRequestService {
 
 export interface ApiGetPullRequest {
     draft: boolean;
-    rebaseable: boolean;
+    rebaseable: boolean | null;
     mergeableState: MergeableState;
     labels: string[];
 }

--- a/src/Github/__tests__/githubPullRequestInfoProvider.test.ts
+++ b/src/Github/__tests__/githubPullRequestInfoProvider.test.ts
@@ -91,4 +91,45 @@ describe('The pull request info is retried', () => {
         /* Then */
         expect(result.mergeableState).toBe('unknown');
     });
+
+    it('when rebaseable is null', async () => {
+        /* Given */
+        getPullRequestService.results.push({
+            draft: false,
+            rebaseable: null,
+            mergeableState: 'behind',
+            labels: [],
+        });
+
+        getPullRequestService.results.push({
+            draft: false,
+            rebaseable: true,
+            mergeableState: 'behind',
+            labels: [],
+        });
+
+        /* When */
+        const result = await provider.pullRequestInfoFor('owner', 'repo', 3);
+
+        /* Then */
+        expect(result.rebaseable).toBe(true);
+    });
+
+    it('when rebaseable is null after max retries, defaults to false', async () => {
+        /* Given */
+        for (let i = 0; i < 10; i++) {
+            getPullRequestService.results.push({
+                draft: false,
+                rebaseable: null,
+                mergeableState: 'behind',
+                labels: [],
+            });
+        }
+
+        /* When */
+        const result = await provider.pullRequestInfoFor('owner', 'repo', 3);
+
+        /* Then */
+        expect(result.rebaseable).toBe(false);
+    });
 });

--- a/src/Github/githubPullRequestInfoProvider.ts
+++ b/src/Github/githubPullRequestInfoProvider.ts
@@ -11,43 +11,47 @@ export class GithubPullRequestInfoProvider {
         repoName: string,
         pullRequestNumber: number,
     ): Promise<PullRequestInfo> {
-        return promiseRetry<PullRequestInfo>(
-            async (attemptNumber): Promise<PullRequestInfo> => {
-                try {
-                    const {draft, rebaseable, mergeableState, labels} = await this.getPullRequestService.getPullRequest(
-                        ownerName,
-                        repoName,
-                        pullRequestNumber,
-                    );
+        return promiseRetry<PullRequestInfo>(async (attemptNumber): Promise<PullRequestInfo> => {
+            try {
+                const {draft, rebaseable, mergeableState, labels} = await this.getPullRequestService.getPullRequest(
+                    ownerName,
+                    repoName,
+                    pullRequestNumber,
+                );
 
-                    if (attemptNumber < 10 && !draft) {
-                        if (mergeableState === 'unknown' || !mergeableStates.includes(mergeableState)) {
-                            debug(`mergeableState for pull request #${pullRequestNumber} is 'unknown', retrying.`);
-                            throw Error("mergeableState is 'unknown'");
-                        }
+                if (attemptNumber < 10 && !draft) {
+                    if (mergeableState === 'unknown' || !mergeableStates.includes(mergeableState)) {
+                        debug(`mergeableState for pull request #${pullRequestNumber} is 'unknown', retrying.`);
+                        throw Error("mergeableState is 'unknown'");
                     }
-
-                    debug(`rebaseable value for pull request #${pullRequestNumber}: ${String(rebaseable)}`);
-                    debug(`mergeableState for pull request #${pullRequestNumber}: ${mergeableState}`);
-
-                    return {
-                        ownerName: ownerName,
-                        repoName: repoName,
-                        number: pullRequestNumber,
-                        draft: draft,
-                        rebaseable: rebaseable,
-                        mergeableState: mergeableState,
-                        labels: labels,
-                    };
-                } catch (error) {
-                    debug(
-                        `Fetching mergeableState for pull request #${pullRequestNumber} failed: "${String(
-                            error,
-                        )}", retrying.`,
-                    );
-                    throw error;
+                    if (rebaseable === null) {
+                        debug(
+                            `rebaseable for pull request #${pullRequestNumber} is null (not yet computed), retrying.`,
+                        );
+                        throw Error('rebaseable is null');
+                    }
                 }
-            },
-        );
+
+                debug(`rebaseable value for pull request #${pullRequestNumber}: ${String(rebaseable)}`);
+                debug(`mergeableState for pull request #${pullRequestNumber}: ${mergeableState}`);
+
+                return {
+                    ownerName: ownerName,
+                    repoName: repoName,
+                    number: pullRequestNumber,
+                    draft: draft,
+                    rebaseable: rebaseable ?? false,
+                    mergeableState: mergeableState,
+                    labels: labels,
+                };
+            } catch (error) {
+                debug(
+                    `Fetching mergeableState for pull request #${pullRequestNumber} failed: "${String(
+                        error,
+                    )}", retrying.`,
+                );
+                throw error;
+            }
+        });
     }
 }


### PR DESCRIPTION
## Summary
- GitHub's API computes `rebaseable` asynchronously and returns `null` while pending
- The existing retry logic handled `mergeableState === 'unknown'` but not `rebaseable === null`, causing eligible PRs to be incorrectly skipped with "PR #X is not rebaseable"
- Added retry logic for `null` rebaseable (same pattern as mergeableState), with fallback to `false` after max retries

## Test plan
- [x] Added test: retry succeeds when `rebaseable` transitions from `null` to `true`
- [x] Added test: defaults to `false` after max retries exhausted
- [x] All 35 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)